### PR TITLE
Potential fix for code scanning alert no. 62: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -69,12 +69,11 @@ public class CommentsCache {
       throws XMLStreamException, JAXBException {
     var jc = JAXBContext.newInstance(Comment.class);
     var xif = XMLInputFactory.newInstance();
-
-    // TODO fix me disabled for now.
-    if (securityEnabled) {
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
-    }
+    // Always securely configure XMLInputFactory to prevent XXE
+    xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+    xif.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Disallow external DTDs
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // Disallow external schemas
 
     var xsr = xif.createXMLStreamReader(new StringReader(xml));
 


### PR DESCRIPTION
Potential fix for [https://github.com/kalinowskiremi/WebGoat/security/code-scanning/62](https://github.com/kalinowskiremi/WebGoat/security/code-scanning/62)

The best way to fix this problem is *always* disabling DTDs, external entity expansion, and restricting schema access for XML parsers that may consume untrusted or user-provided data. Do not rely on an optional "securityEnabled" flag: safety should be the default for all paths that involve untrusted (user input) XML.

Specifically, in `CommentsCache.java`, in the `parseXml` method, you should always set the relevant safe features and properties on your `XMLInputFactory`, regardless of any conditional flag. For best practice, apply the following:
- Set `XMLInputFactory.SUPPORT_DTD` to `false`
- Set `XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES` to `false`
- Set `XMLConstants.ACCESS_EXTERNAL_DTD` to ""
- Set `XMLConstants.ACCESS_EXTERNAL_SCHEMA` to ""

In addition, consider disallowing the parsing of DTDs altogether and ensure the parser implementation respects these settings (which the default Java XML stream implementation will).

You will need to update `parseXml` so that the above features are always set before `createXMLStreamReader` is invoked. Remove the conditional on `securityEnabled`—always apply these mitigations.

Change only the code inside `src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java`, specifically in the `parseXml` method.

No external dependencies are needed, as all mitigations are supported by standard Java SE/Jakarta EE APIs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
